### PR TITLE
Allow mime-types to be transitively depended upon at a modern version.

### DIFF
--- a/linkedin-v2.gemspec
+++ b/linkedin-v2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "oauth2",  "~> 1.0"
   gem.add_dependency "hashie",  "~> 3.2"
   gem.add_dependency "faraday", "~> 0.11"
-  gem.add_dependency 'mime-types', '~> 1.16'
+  gem.add_dependency 'mime-types', '>= 1.16'
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Hi there!

What do you think about loosening the version requirement on mime-types to allow modern versions ?  I've seen >= 1.16 a lot as an idiom, rather than ~> 1.16 . 

-Tim Heilman
