### PR TITLE
loosen dependency on hashie to remove version conflict with omniauth

### DIFF
--- a/linkedin-v2.gemspec
+++ b/linkedin-v2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_dependency "oauth2",  "~> 1.0"
-  gem.add_dependency "hashie",  "~> 3.2"
+  gem.add_dependency "hashie",  ">= 3.2"
   gem.add_dependency "faraday", "~> 1.0"
   gem.add_dependency 'mime-types', '>= 1.16'
 


### PR DESCRIPTION
There's a dependency conflict with omniauth and omniauth-oauth2 which I assume many users of this gem will also be using. This PR just removes the strict dependency on hashie 3.2.0