### PR TITLE
Media assets endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,107 @@
+PATH
+  remote: .
+  specs:
+    linkedin-v2 (0.1.9)
+      faraday (~> 1.0)
+      hashie (>= 3.2)
+      mime-types (>= 1.16)
+      oauth2 (~> 1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    coveralls (0.8.23)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
+      term-ansicolor (~> 1.3)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
+    crack (0.4.5)
+      rexml
+    diff-lcs (1.4.4)
+    docile (1.4.0)
+    faraday (1.8.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    hashdiff (1.0.1)
+    hashie (5.0.0)
+    json (2.6.1)
+    jwt (2.3.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.1115)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
+    oauth2 (1.4.7)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    public_suffix (4.0.6)
+    rack (2.2.3)
+    rake (13.0.6)
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.3)
+    ruby2_keywords (0.0.5)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
+    thor (1.1.0)
+    tins (1.29.1)
+      sync
+    vcr (6.0.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+
+PLATFORMS
+  arm64-darwin-20
+
+DEPENDENCIES
+  coveralls
+  linkedin-v2!
+  rake
+  rspec (~> 3.0)
+  vcr
+  webmock
+
+BUNDLED WITH
+   2.2.28

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -65,7 +65,8 @@ module LinkedIn
                                               :migrate_update_keys
 
     def_delegators :@media, :summary,
-                            :upload
+                            :upload,
+                            :register_upload
 
     private ##############################################################
 
@@ -89,7 +90,7 @@ module LinkedIn
 
     def default_headers
       # https://developer.linkedin.com/documents/api-requests-json
-      return {"x-li-format" => "json", "Authorization" => "Bearer #{@access_token.token}"}
+      return {"X-Restli-Protocol-Version" => "2.0.0", "x-li-format" => "json", "Authorization" => "Bearer #{@access_token.token}"}
     end
 
     def verify_access_token!(access_token)

--- a/lib/linked_in/api_resource.rb
+++ b/lib/linked_in/api_resource.rb
@@ -66,7 +66,7 @@ module LinkedIn
 
     def put(path=nil, body=nil, headers=nil, &block)
       @connection.put(prepend_prefix(path), body, headers, &block)
-      Mash.from_json(response.body)
+      #Mash.from_json(response.body)
     end
 
     def delete(path=nil, body=nil, headers=nil, &block)

--- a/lib/linked_in/media.rb
+++ b/lib/linked_in/media.rb
@@ -19,6 +19,8 @@ module LinkedIn
     # @see https://developer.linkedin.com/docs/guide/v2/shares/rich-media-shares#upload
     #
     # @options options [String] :source_url, the URL to the content to be uploaded.
+    # @options options [String] :type, the type of URN to use (person or organization).
+    # @options options [String] :urn, the URN of the entity uploading.
     # @options options [Numeric] :timeout, optional timeout value in seconds, defaults to 300.
     # @options options [String] :disposition_filename, the name of the file to be uploaded. Defaults to the basename of the URL filename.
     # @return [LinkedIn::Mash]
@@ -26,17 +28,59 @@ module LinkedIn
     def upload(options = {})
       source_url = options.delete(:source_url)
       timeout = options.delete(:timeout) || DEFAULT_TIMEOUT_SECONDS
-      media_upload_endpoint = LinkedIn.config.api + '/media/upload'
+      type = options.delete(:type)
+      urn = options.delete(:urn)
+
+      responseHash = register_upload(type: type, urn: urn)
+      media_upload_endpoint = responseHash.dig("value", "upload_mechanism", "com.linkedin.digitalmedia.uploading.media_upload_http_request", "upload_url")
+      asset_urn = responseHash.dig("value", "asset")
+
       response =
-        @connection.post(media_upload_endpoint, file: file(source_url, options)) do |req|
+        @connection.put(media_upload_endpoint, file: file(source_url, options)) do |req|
           req.headers['Accept'] = 'application/json'
           req.options.timeout = timeout
           req.options.open_timeout = timeout
         end
-      Mash.from_json(response.body)
+      if response.status == 201
+        asset_urn
+      else
+        raise InvalidRequest.new(response.message)
+      end
     end
 
-    private
+    # Registers a media upload with LinkedIn providing the upload URL and asset ID.
+    #
+    # @see https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/vector-asset-api?tabs=http
+    #
+    # @options options [String] :type, the type of URN to use (person or organization).
+    # @options options [String] :urn, the URN of the entity uploading.
+    #
+    def register_upload(options = {})
+      register_upload_endpoint = '/assets?action=registerUpload'
+      type = options.delete(:type)
+      urn = options.delete(:urn)
+
+      registerRequest = {
+          registerUploadRequest: {
+            owner: "urn:li:#{type}:#{urn}",
+            recipes: [
+                "urn:li:digitalmediaRecipe:feedshare-image"
+            ],
+            serviceRelationships: [
+                {
+                  identifier: "urn:li:userGeneratedContent",
+                  relationshipType: "OWNER"
+                }
+            ],
+            supportedUploadMechanism: [
+                "SYNCHRONOUS_UPLOAD"
+            ]
+          }
+      }
+
+      registerUploadResponse = post(register_upload_endpoint, MultiJson.dump(registerRequest))
+      Mash.from_json(registerUploadResponse.body)
+    end
 
     def upload_filename(media)
       File.basename(media.base_uri.request_uri)

--- a/lib/linked_in/media.rb
+++ b/lib/linked_in/media.rb
@@ -14,39 +14,39 @@ module LinkedIn
       get(path, options)
     end
 
-    # Uploads rich media content to LinkedIn from a supplied URL.
-    #
-    # @see https://developer.linkedin.com/docs/guide/v2/shares/rich-media-shares#upload
-    #
-    # @options options [String] :source_url, the URL to the content to be uploaded.
-    # @options options [String] :type, the type of URN to use (person or organization).
-    # @options options [String] :urn, the URN of the entity uploading.
-    # @options options [Numeric] :timeout, optional timeout value in seconds, defaults to 300.
-    # @options options [String] :disposition_filename, the name of the file to be uploaded. Defaults to the basename of the URL filename.
-    # @return [LinkedIn::Mash]
-    #
-    def upload(options = {})
-      source_url = options.delete(:source_url)
-      timeout = options.delete(:timeout) || DEFAULT_TIMEOUT_SECONDS
-      type = options.delete(:type)
-      urn = options.delete(:urn)
+  # Uploads rich media content to LinkedIn from a supplied URL.
+  #
+  # @see https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/vector-asset-api?tabs=http#upload-the-image
+  #
+  # @options options [String] :source_url, the URL to the content to be uploaded.
+  # @options options [String] :type, the type of URN to use (person or organization).
+  # @options options [String] :urn, the URN of the entity uploading.
+  # @options options [Numeric] :timeout, optional timeout value in seconds, defaults to 300.
+  # @options options [String] :disposition_filename, the name of the file to be uploaded. Defaults to the basename of the URL filename.
+  # @return [LinkedIn::Mash]
+  #
+  def upload(options = {})
+    source_url = options.delete(:source_url)
+    timeout = options.delete(:timeout) || DEFAULT_TIMEOUT_SECONDS
+    type = options.delete(:type)
+    urn = options.delete(:urn)
 
-      responseHash = register_upload(type: type, urn: urn)
-      media_upload_endpoint = responseHash.dig("value", "upload_mechanism", "com.linkedin.digitalmedia.uploading.media_upload_http_request", "upload_url")
-      asset_urn = responseHash.dig("value", "asset")
+    responseHash = register_upload(type: type, urn: urn)
+    media_upload_endpoint = responseHash.dig("value", "upload_mechanism", "com.linkedin.digitalmedia.uploading.media_upload_http_request", "upload_url")
+    asset_urn = responseHash.dig("value", "asset")
 
-      response =
-        @connection.put(media_upload_endpoint, file: file(source_url, options)) do |req|
-          req.headers['Accept'] = 'application/json'
-          req.options.timeout = timeout
-          req.options.open_timeout = timeout
-        end
-      if response.status == 201
-        asset_urn
-      else
-        raise InvalidRequest.new(response.message)
+    response =
+      @connection.put(media_upload_endpoint, file: file(source_url, options)) do |req|
+        req.headers['Accept'] = 'application/json'
+        req.options.timeout = timeout
+        req.options.open_timeout = timeout
       end
+    if response.status == 201
+      asset_urn
+    else
+      raise InvalidRequest.new(response.message)
     end
+  end
 
     # Registers a media upload with LinkedIn providing the upload URL and asset ID.
     #

--- a/linkedin-v2.gemspec
+++ b/linkedin-v2.gemspec
@@ -30,9 +30,9 @@ Gem::Specification.new do |gem|
 
   # We use YARD for documentation
   # Extra gems for GitHub flavored MarkDown in YARD
-  gem.add_development_dependency "yard"
-  gem.add_development_dependency "redcarpet"
-  gem.add_development_dependency "github-markdown"
+  # gem.add_development_dependency "yard"
+  # gem.add_development_dependency "redcarpet"
+  # gem.add_development_dependency "github-markdown"
 
   # We use VCR to mock LinkedIn API calls
   gem.add_development_dependency "vcr"

--- a/spec/linked_in/api/media_spec.rb
+++ b/spec/linked_in/api/media_spec.rb
@@ -1,19 +1,43 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe LinkedIn::Media do
-  let(:access_token) { 'dummy_access_token' }
+  let(:access_token) { "dummy_access_token" }
   let(:api) { LinkedIn::API.new(access_token) }
-  let(:base_uri) { double('uri', request_uri: 'http://example.org/elvis.png') }
-  let(:media) { double('media', size: 2048, base_uri: base_uri).as_null_object }
+  let(:base_uri) { double("uri", request_uri: "http://example.org/elvis.png") }
+  let(:media) { double("media", size: 2048, base_uri: base_uri).as_null_object }
+  let(:type) { "person" }
+  let(:urn) { "12345678" }
+  let(:upload_url) { "https://api.linkedin.com/mediaUpload/foobar" }
+  let(:upload_register_response) {
+    '{
+      "value": {
+          "uploadMechanism": {
+              "com.linkedin.digitalmedia.uploading.MediaUploadHttpRequest": {
+                  "headers": {
+                      "media-type-family": "STILLIMAGE"
+                  },
+                  "uploadUrl": "' + upload_url + '"
+              }
+          },
+          "mediaArtifact": "urn:li:digitalmediaMediaArtifact:(urn:li:digitalmediaAsset:C5522AQHn46pwH96hxQ,urn:li:digitalmediaMediaArtifactClass:feedshare-uploadedImage)",
+          "asset": "urn:li:digitalmediaAsset:C5522AQHn46pwH96hxQ"
+      }
+    }'
+  }
 
   before do
     allow_any_instance_of(LinkedIn::Media).to receive(:open).and_return(media)
   end
 
+  it "should get an upload url" do
+    stub_request(:post, "https://api.linkedin.com/v2/assets?action=registerUpload").to_return(body: upload_register_response)
+    expect(api.register_upload(type: type, urn: urn)).to eq(LinkedIn::Mash.from_json(upload_register_response))
+  end
+
   it "should be able to upload media" do
-    result = '{"location": "urn:li:richMediaSummary:PNG-IMG-54f022ae8b3f4d479e925b4df68e19"}'
-    stub_request(:post, 'https://api.linkedin.com/media/upload').to_return(body: result)
+    stub_request(:post, "https://api.linkedin.com/v2/assets?action=registerUpload").to_return(body: upload_register_response)
+    stub_request(:put, upload_url).to_return(status: 201, body: '{"asset": "urn:li:digitalmediaAsset:C5522AQHn46pwH96hxQ"}')
     expect(api.upload(source_url: "#{File.dirname(__FILE__)}/../../fixtures/elvis.jpg"))
-      .to eq("location" => "urn:li:richMediaSummary:PNG-IMG-54f022ae8b3f4d479e925b4df68e19")
+      .to eq("urn:li:digitalmediaAsset:C5522AQHn46pwH96hxQ")
   end
 end

--- a/spec/vcr_cassettes/access_token_success.yml
+++ b/spec/vcr_cassettes/access_token_success.yml
@@ -94,6 +94,92 @@ http_interactions:
         to handle the request : RestException{_response=RestResponse[headers={Content-Length=10592,
         Content-Type=application/json, X-RestLi-Error-Response=true, X-RestLi-Protocol-Version=2.0.0}cookies=[],status=404,entityLength=10592]}
         ","error":"temporarily_unavailable"}'
-    http_version: 
   recorded_at: Mon, 21 May 2018 18:34:12 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: post
+    uri: https://www.linkedin.com/oauth/v2/accessToken
+    body:
+      encoding: UTF-8
+      string: client_id=dummy_client_id&client_secret=dummy_client_secret&code=dummy_code&grant_type=authorization_code&raise_errors=true&redirect_uri=http%3A%2F%2Flvh.me%3A5000
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '116'
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Vary:
+      - Accept-Encoding
+      Set-Cookie:
+      - bcookie="v=2&22006082-3d1c-48eb-83b7-48f2821a33a0"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:43 GMT; SameSite=None
+      - bscookie="v=1&20220112213711a9a02a7f-d67b-43e8-86f1-db91217a8799AQFsaDNm1QaW9U2zWFMqF1uwoe4p2eIP";
+        domain=.www.linkedin.com; Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:43
+        GMT; HttpOnly; SameSite=None
+      - lang=v=2&lang=en-us; SameSite=None; Path=/; Domain=linkedin.com; Secure
+      - lidc="b=VB01:s=V:r=V:a=V:p=V:g=4501:u=1:x=1:i=1642023431:t=1642109831:v=2:sig=AQHucF8GZCQCeTeyQ48scid3xHYSXVpr";
+        Expires=Thu, 13 Jan 2022 21:37:11 GMT; domain=.linkedin.com; Path=/; SameSite=None;
+        Secure
+      Expect-Ct:
+      - max-age=86400, report-uri="https://www.linkedin.com/platform-telemetry/ct"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - 'default-src *; connect-src ''self'' https://media-src.linkedin.com/media/
+        www.linkedin.com s.c.lnkd.licdn.com m.c.lnkd.licdn.com wss://*.linkedin.com
+        dms.licdn.com https://dpm.demdex.net/id lnkd.demdex.net blob: https://accounts.google.com/gsi/status
+        https://linkedin.sc.omtrdc.net/b/ss/ www.google-analytics.com static.licdn.com
+        static-exp1.licdn.com static-exp2.licdn.com static-exp3.licdn.com media.licdn.com
+        media-exp1.licdn.com media-exp2.licdn.com media-exp3.licdn.com; img-src data:
+        blob: *; font-src data: *; style-src ''unsafe-inline'' ''self'' static-src.linkedin.com
+        *.licdn.com; script-src ''report-sample'' ''unsafe-inline'' ''unsafe-eval''
+        ''self'' spdy.linkedin.com static-src.linkedin.com *.ads.linkedin.com *.licdn.com
+        static.chartbeat.com www.google-analytics.com ssl.google-analytics.com bcvipva02.rightnowtech.com
+        www.bizographics.com sjs.bizographics.com js.bizographics.com d.la4-c1-was.salesforceliveagent.com
+        https://snap.licdn.com/li.lms-analytics/ platform.linkedin.com platform-akam.linkedin.com
+        platform-ecst.linkedin.com platform-azur.linkedin.com; object-src ''none'';
+        media-src blob: *; child-src blob: lnkd-communities: voyager: *; frame-ancestors
+        ''self''; report-uri /security/csp?e=p&f=l'
+      X-Frame-Options:
+      - sameorigin
+      X-Li-Fabric:
+      - prod-lva1
+      X-Fs-Uuid:
+      - 0005d5695f537c008a96aa30ea5f9425
+      X-Li-Pop:
+      - afd-prod-lva1-x
+      X-Li-Proto:
+      - http/1.1
+      X-Li-Uuid:
+      - AAXVaV9TfACKlqow6l+UJQ==
+      X-Cache:
+      - CONFIG_NOCACHE
+      X-Msedge-Ref:
+      - 'Ref A: 9E99BAD1739343F08DF2273D1968FF42 Ref B: BNA30EDGE0117 Ref C: 2022-01-12T21:37:11Z'
+      Date:
+      - Wed, 12 Jan 2022 21:37:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":"invalid_request","error_description":"Unable to retrieve
+        access token: authorization code not found"}'
+  recorded_at: Wed, 12 Jan 2022 21:37:11 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/bad_code.yml
+++ b/spec/vcr_cassettes/bad_code.yml
@@ -94,6 +94,92 @@ http_interactions:
         to handle the request : RestException{_response=RestResponse[headers={Content-Length=10592,
         Content-Type=application/json, X-RestLi-Error-Response=true, X-RestLi-Protocol-Version=2.0.0}cookies=[],status=404,entityLength=10592]}
         ","error":"temporarily_unavailable"}'
-    http_version: 
   recorded_at: Mon, 21 May 2018 18:34:13 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: post
+    uri: https://www.linkedin.com/oauth/v2/accessToken
+    body:
+      encoding: UTF-8
+      string: client_id=dummy_client_id&client_secret=dummy_client_secret&code=dummy_code&grant_type=authorization_code&raise_errors=true&redirect_uri=http%3A%2F%2Flvh.me%3A5000
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '116'
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Vary:
+      - Accept-Encoding
+      Set-Cookie:
+      - bcookie="v=2&9b8fc6b3-bd78-4e3e-8989-5e8a0e38641c"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:43 GMT; SameSite=None
+      - bscookie="v=1&20220112213711e48e6cfb-574f-49fb-8197-499a5362e14dAQGP_Q6wiLX4gKquzTS3WsHSAnlnmhfw";
+        domain=.www.linkedin.com; Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:43
+        GMT; HttpOnly; SameSite=None
+      - lang=v=2&lang=en-us; SameSite=None; Path=/; Domain=linkedin.com; Secure
+      - lidc="b=VB32:s=V:r=V:a=V:p=V:g=3703:u=1:x=1:i=1642023431:t=1642109831:v=2:sig=AQHWkVCt5g9M-jXE3FDSifbBitCBSGum";
+        Expires=Thu, 13 Jan 2022 21:37:11 GMT; domain=.linkedin.com; Path=/; SameSite=None;
+        Secure
+      Expect-Ct:
+      - max-age=86400, report-uri="https://www.linkedin.com/platform-telemetry/ct"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - 'default-src *; connect-src ''self'' https://media-src.linkedin.com/media/
+        www.linkedin.com s.c.lnkd.licdn.com m.c.lnkd.licdn.com wss://*.linkedin.com
+        dms.licdn.com https://dpm.demdex.net/id lnkd.demdex.net blob: https://accounts.google.com/gsi/status
+        https://linkedin.sc.omtrdc.net/b/ss/ www.google-analytics.com static.licdn.com
+        static-exp1.licdn.com static-exp2.licdn.com static-exp3.licdn.com media.licdn.com
+        media-exp1.licdn.com media-exp2.licdn.com media-exp3.licdn.com; img-src data:
+        blob: *; font-src data: *; style-src ''unsafe-inline'' ''self'' static-src.linkedin.com
+        *.licdn.com; script-src ''report-sample'' ''unsafe-inline'' ''unsafe-eval''
+        ''self'' spdy.linkedin.com static-src.linkedin.com *.ads.linkedin.com *.licdn.com
+        static.chartbeat.com www.google-analytics.com ssl.google-analytics.com bcvipva02.rightnowtech.com
+        www.bizographics.com sjs.bizographics.com js.bizographics.com d.la4-c1-was.salesforceliveagent.com
+        https://snap.licdn.com/li.lms-analytics/ platform.linkedin.com platform-akam.linkedin.com
+        platform-ecst.linkedin.com platform-azur.linkedin.com; object-src ''none'';
+        media-src blob: *; child-src blob: lnkd-communities: voyager: *; frame-ancestors
+        ''self''; report-uri /security/csp?e=p&f=l'
+      X-Frame-Options:
+      - sameorigin
+      X-Li-Fabric:
+      - prod-lva1
+      X-Fs-Uuid:
+      - 0005d5695f584c5df5a97f0d6ee0dcd6
+      X-Li-Pop:
+      - afd-prod-lva1-x
+      X-Li-Proto:
+      - http/1.1
+      X-Li-Uuid:
+      - AAXVaV9YTF31qX8NbuDc1g==
+      X-Cache:
+      - CONFIG_NOCACHE
+      X-Msedge-Ref:
+      - 'Ref A: 527F89A64096433CB0457B8125E1315F Ref B: BNA30EDGE0111 Ref C: 2022-01-12T21:37:11Z'
+      Date:
+      - Wed, 12 Jan 2022 21:37:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":"invalid_request","error_description":"Unable to retrieve
+        access token: authorization code not found"}'
+  recorded_at: Wed, 12 Jan 2022 21:37:11 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/organization_data.yml
+++ b/spec/vcr_cassettes/organization_data.yml
@@ -12,7 +12,7 @@ http_interactions:
       Authorization:
       - Bearer dummy access token
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -22,30 +22,34 @@ http_interactions:
       code: 401
       message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '72'
       Date:
-      - Mon, 21 May 2018 18:33:58 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:03 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
       X-Li-Uuid:
-      - 4gmX75i8MBXwaQZpdSsAAA==
+      - AAXVaV7Y78LE2DyBJ0sWNw==
       Set-Cookie:
-      - lidc="b=VB90:g=1300:u=1:i=1526927638:t=1527014038:s=AQG3FreU8caYTQ4iqgrhldrSZfnYJyGm";
-        Expires=Tue, 22 May 2018 18:33:58 GMT; domain=.linkedin.com; Path=/
+      - bcookie="v=2&b3733836-da39-4832-81d0-7719d8e203e7"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:35 GMT; SameSite=None
+      - lidc="b=VB70:s=V:r=V:a=V:p=V:g=2859:u=1:x=1:i=1642023423:t=1642109823:v=2:sig=AQGAAkW_E0BMGti6JfLE0Bndyx5Zh3iu";
+        Expires=Thu, 13 Jan 2022 21:37:03 GMT; domain=.linkedin.com; Path=/; SameSite=None;
+        Secure
     body:
       encoding: UTF-8
       string: '{"serviceErrorCode":65600,"message":"Invalid access token","status":401}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:33:58 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 12 Jan 2022 21:37:03 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_picture_urls.yml
+++ b/spec/vcr_cassettes/people_picture_urls.yml
@@ -12,41 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:07 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:06 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927647:t=1527014039:s=AQEwT_cbxGx23wr3JMnnQ-NGnx46htzD"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927647:t=1527014039:s=AQEwT_cbxGx23wr3JMnnQ-NGnx46htzD"'
       X-Li-Uuid:
-      - nMkwA5u8MBXw4zBOSysAAA==
+      - AAXVaV8RFYkHXLZEsQvzNQ==
+      Set-Cookie:
+      - bcookie="v=2&0d2b4b7f-a90b-46b0-8ede-f5a14d023874"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:38 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023426:t=1642025283:v=2:sig=AQEZvIKTWpnHazXJ1WA0C2Wj_0fSMKZk"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023426:t=1642025283:v=2:sig=AQEZvIKTWpnHazXJ1WA0C2Wj_0fSMKZk"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Resource me does not exist","status":404}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:07 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:06 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_connections_fields.yml
+++ b/spec/vcr_cassettes/people_profile_connections_fields.yml
@@ -12,41 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:05 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:05 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927645:t=1527014039:s=AQFrPI31qW1Sjy3IkWDRhXJC4um4wevV"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927645:t=1527014039:s=AQFrPI31qW1Sjy3IkWDRhXJC4um4wevV"'
       X-Li-Uuid:
-      - izRRfZq8MBVQ3oUcSisAAA==
+      - AAXVaV8CX9ZhnecG8Z72OQ==
+      Set-Cookie:
+      - bcookie="v=2&c282e655-bb44-4d42-8c4b-dcbb42e4cfe9"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:37 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023425:t=1642025283:v=2:sig=AQGdWom0Zpcouv7CcndA6naq2Km5zdfY"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023425:t=1642025283:v=2:sig=AQGdWom0Zpcouv7CcndA6naq2Km5zdfY"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Resource me does not exist","status":404}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:05 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:05 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_connections_other.yml
+++ b/spec/vcr_cassettes/people_profile_connections_other.yml
@@ -12,41 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:05 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:05 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927645:t=1527014039:s=AQFrPI31qW1Sjy3IkWDRhXJC4um4wevV"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927645:t=1527014039:s=AQFrPI31qW1Sjy3IkWDRhXJC4um4wevV"'
       X-Li-Uuid:
-      - BPKiaZq8MBXgWcuRSSsAAA==
+      - AAXVaV7/+RaOuTEncQg2AA==
+      Set-Cookie:
+      - bcookie="v=2&42fe13dd-8a31-404b-8427-ca05636ce312"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:37 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023425:t=1642025283:v=2:sig=AQGdWom0Zpcouv7CcndA6naq2Km5zdfY"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023425:t=1642025283:v=2:sig=AQGdWom0Zpcouv7CcndA6naq2Km5zdfY"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Resource people does not exist","status":404}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:05 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:05 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_connections_self.yml
+++ b/spec/vcr_cassettes/people_profile_connections_self.yml
@@ -12,41 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:04 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:05 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927644:t=1527014039:s=AQGfRcUjlELOGzxb-64ifolyV9fKbUsp"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927644:t=1527014039:s=AQGfRcUjlELOGzxb-64ifolyV9fKbUsp"'
       X-Li-Uuid:
-      - GWd4VJq8MBVw8Grs1CoAAA==
+      - AAXVaV79pHLt0h6DK7yDCQ==
+      Set-Cookie:
+      - bcookie="v=2&9bbfa25e-c90c-42a3-8a46-9252dbda13a7"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:37 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023425:t=1642025283:v=2:sig=AQGdWom0Zpcouv7CcndA6naq2Km5zdfY"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023425:t=1642025283:v=2:sig=AQGdWom0Zpcouv7CcndA6naq2Km5zdfY"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Resource me does not exist","status":404}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:04 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:05 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_fields_complex.yml
+++ b/spec/vcr_cassettes/people_profile_fields_complex.yml
@@ -12,41 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 400
-      message: Bad Request
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:03 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:04 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927642:t=1527014039:s=AQHHr3k2NymZYYLggEBOGWkjd-EZukzd"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927642:t=1527014039:s=AQHHr3k2NymZYYLggEBOGWkjd-EZukzd"'
       X-Li-Uuid:
-      - spia5pm8MBVQo+R6SisAAA==
+      - AAXVaV7wvCpDLVQKZedpTw==
+      Set-Cookie:
+      - bcookie="v=2&e323ad3d-feec-4fa1-8502-f852c6060d40"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:36 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023424:t=1642025283:v=2:sig=AQG9cK7snZdg2V-yqDzMEAMeFEUJiOoP"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023424:t=1642025283:v=2:sig=AQG9cK7snZdg2V-yqDzMEAMeFEUJiOoP"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Illegal field name ''[''","status":400}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:03 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:04 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_fields_simple.yml
+++ b/spec/vcr_cassettes/people_profile_fields_simple.yml
@@ -12,41 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 400
-      message: Bad Request
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:02 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:04 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927642:t=1527014039:s=AQHHr3k2NymZYYLggEBOGWkjd-EZukzd"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927642:t=1527014039:s=AQHHr3k2NymZYYLggEBOGWkjd-EZukzd"'
       X-Li-Uuid:
-      - 8Lg9zZm8MBUAVDdfdSsAAA==
+      - AAXVaV7uO4YiVCZfA90k9w==
+      Set-Cookie:
+      - bcookie="v=2&ff356046-cd5b-45c2-8acc-da6c8bb4b048"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:36 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023424:t=1642025283:v=2:sig=AQG9cK7snZdg2V-yqDzMEAMeFEUJiOoP"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023424:t=1642025283:v=2:sig=AQG9cK7snZdg2V-yqDzMEAMeFEUJiOoP"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Illegal field name ''[''","status":400}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:02 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:04 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_lang_spanish.yml
+++ b/spec/vcr_cassettes/people_profile_lang_spanish.yml
@@ -12,42 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 403
-      message: Forbidden
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:00 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:03 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927640:t=1527014039:s=AQEVqLqcGRCKt0iUhP3f4TCawRzfgV4D"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927640:t=1527014039:s=AQEVqLqcGRCKt0iUhP3f4TCawRzfgV4D"'
       X-Li-Uuid:
-      - hPbOQZm8MBXw/ZVXSisAAA==
+      - AAXVaV7hj1/0HU4Midi0uw==
+      Set-Cookie:
+      - bcookie="v=2&56b8f1b5-590d-41f3-854f-7b737bdd5231"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:35 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023423:t=1642025283:v=2:sig=AQFdi9Qro7L-lDc92ApInuGYvWinMXDm"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023423:t=1642025283:v=2:sig=AQFdi9Qro7L-lDc92ApInuGYvWinMXDm"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":100,"message":"Unpermitted fields present in PARAMETER:
-        Data Processing Exception while processing fields [/lang]","status":403}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:00 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:03 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_multiple_fields.yml
+++ b/spec/vcr_cassettes/people_profile_multiple_fields.yml
@@ -12,41 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:04 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:05 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927644:t=1527014039:s=AQGfRcUjlELOGzxb-64ifolyV9fKbUsp"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927644:t=1527014039:s=AQGfRcUjlELOGzxb-64ifolyV9fKbUsp"'
       X-Li-Uuid:
-      - IdT8Ppq8MBVwzHNc1ioAAA==
+      - AAXVaV77LKq1E4yIRa4Zcg==
+      Set-Cookie:
+      - bcookie="v=2&2edbcea8-a8d3-4ade-84a7-b2fed263c943"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:37 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023425:t=1642025283:v=2:sig=AQGdWom0Zpcouv7CcndA6naq2Km5zdfY"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023425:t=1642025283:v=2:sig=AQGdWom0Zpcouv7CcndA6naq2Km5zdfY"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Resource null does not exist","status":404}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:04 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:05 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_multiple_uids.yml
+++ b/spec/vcr_cassettes/people_profile_multiple_uids.yml
@@ -12,41 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:03 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:04 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927643:t=1527014039:s=AQG_2xQYlw_faTs_OuVK_Wb4tsK9QLVt"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927643:t=1527014039:s=AQG_2xQYlw_faTs_OuVK_Wb4tsK9QLVt"'
       X-Li-Uuid:
-      - aI/vAJq8MBWgr5+JECsAAA==
+      - AAXVaV7zeChoJWViM3fcAA==
+      Set-Cookie:
+      - bcookie="v=2&97591727-a1e8-4120-860f-57928eb0bb26"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:36 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023424:t=1642025283:v=2:sig=AQG9cK7snZdg2V-yqDzMEAMeFEUJiOoP"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023424:t=1642025283:v=2:sig=AQG9cK7snZdg2V-yqDzMEAMeFEUJiOoP"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Resource null does not exist","status":404}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:03 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:04 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_multiple_uids_and_urls.yml
+++ b/spec/vcr_cassettes/people_profile_multiple_uids_and_urls.yml
@@ -12,41 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:04 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:05 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927644:t=1527014039:s=AQGfRcUjlELOGzxb-64ifolyV9fKbUsp"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927644:t=1527014039:s=AQGfRcUjlELOGzxb-64ifolyV9fKbUsp"'
       X-Li-Uuid:
-      - oJC9KZq8MBUgPveJECsAAA==
+      - AAXVaV74vKde6L6L+PKqrg==
+      Set-Cookie:
+      - bcookie="v=2&1000bf42-2205-4ae2-844f-69e193a7831a"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:37 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023425:t=1642025283:v=2:sig=AQGdWom0Zpcouv7CcndA6naq2Km5zdfY"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023425:t=1642025283:v=2:sig=AQGdWom0Zpcouv7CcndA6naq2Km5zdfY"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Resource null does not exist","status":404}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:04 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:05 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_multiple_urls.yml
+++ b/spec/vcr_cassettes/people_profile_multiple_urls.yml
@@ -12,41 +12,49 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:03 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:05 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
+      Report-To:
+      - '{"group":"network-errors","max_age":2592000,"endpoints":[{"url":"https://www.linkedin.com/li/rep"}],"include_subdomains":true}'
+      Nel:
+      - '{"report_to":"network-errors","max_age":1296000,"success_fraction":0.00066,"failure_fraction":1,"include_subdomains":true}'
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927643:t=1527014039:s=AQG_2xQYlw_faTs_OuVK_Wb4tsK9QLVt"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927643:t=1527014039:s=AQG_2xQYlw_faTs_OuVK_Wb4tsK9QLVt"'
       X-Li-Uuid:
-      - 1EMZFpq8MBXwnwLt1CoAAA==
+      - AAXVaV72JErzhPMcJeApoA==
+      Set-Cookie:
+      - bcookie="v=2&6dbda17e-786b-44eb-8238-a7e342af84fc"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:37 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023425:t=1642025283:v=2:sig=AQGdWom0Zpcouv7CcndA6naq2Km5zdfY"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023425:t=1642025283:v=2:sig=AQGdWom0Zpcouv7CcndA6naq2Km5zdfY"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Resource null does not exist","status":404}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:03 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:04 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_new_connections_fields.yml
+++ b/spec/vcr_cassettes/people_profile_new_connections_fields.yml
@@ -12,41 +12,49 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:07 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:06 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
+      Report-To:
+      - '{"group":"network-errors","max_age":2592000,"endpoints":[{"url":"https://www.linkedin.com/li/rep"}],"include_subdomains":true}'
+      Nel:
+      - '{"report_to":"network-errors","max_age":1296000,"success_fraction":0.00066,"failure_fraction":1,"include_subdomains":true}'
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927647:t=1527014039:s=AQEwT_cbxGx23wr3JMnnQ-NGnx46htzD"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927647:t=1527014039:s=AQEwT_cbxGx23wr3JMnnQ-NGnx46htzD"'
       X-Li-Uuid:
-      - "+4Q07pq8MBVQ3AtZECsAAA=="
+      - AAXVaV8OcE7Kxr9VyxlCTQ==
+      Set-Cookie:
+      - bcookie="v=2&217cd3dc-4891-475b-80cf-0656fac62507"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:38 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023426:t=1642025283:v=2:sig=AQEZvIKTWpnHazXJ1WA0C2Wj_0fSMKZk"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023426:t=1642025283:v=2:sig=AQEZvIKTWpnHazXJ1WA0C2Wj_0fSMKZk"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Resource me does not exist","status":404}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:07 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:06 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_new_connections_other.yml
+++ b/spec/vcr_cassettes/people_profile_new_connections_other.yml
@@ -12,41 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:06 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:06 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927646:t=1527014039:s=AQH70OsvZigtL0Vvbzxes8DIaiz2upjx"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927646:t=1527014039:s=AQH70OsvZigtL0Vvbzxes8DIaiz2upjx"'
       X-Li-Uuid:
-      - LtFO15q8MBUgPkfW1CoAAA==
+      - AAXVaV8L7c42cKAJ+S9TvQ==
+      Set-Cookie:
+      - bcookie="v=2&996f6668-89d9-40d1-816b-1814c4feb18a"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:38 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023426:t=1642025283:v=2:sig=AQEZvIKTWpnHazXJ1WA0C2Wj_0fSMKZk"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023426:t=1642025283:v=2:sig=AQEZvIKTWpnHazXJ1WA0C2Wj_0fSMKZk"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Resource people does not exist","status":404}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:07 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:06 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_new_connections_self.yml
+++ b/spec/vcr_cassettes/people_profile_new_connections_self.yml
@@ -12,41 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:06 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:06 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927646:t=1527014039:s=AQH70OsvZigtL0Vvbzxes8DIaiz2upjx"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927646:t=1527014039:s=AQH70OsvZigtL0Vvbzxes8DIaiz2upjx"'
       X-Li-Uuid:
-      - BXX9uZq8MBVggWfs1CoAAA==
+      - AAXVaV8JbVpmhqSo+XuWhg==
+      Set-Cookie:
+      - bcookie="v=2&2c241d15-4f44-4f72-898f-aa106cd43de3"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:38 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023426:t=1642025283:v=2:sig=AQEZvIKTWpnHazXJ1WA0C2Wj_0fSMKZk"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023426:t=1642025283:v=2:sig=AQEZvIKTWpnHazXJ1WA0C2Wj_0fSMKZk"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Resource me does not exist","status":404}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:06 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:06 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_other_uid.yml
+++ b/spec/vcr_cassettes/people_profile_other_uid.yml
@@ -12,46 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 200
-      message: OK
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
+      X-Restli-Gateway-Error:
+      - 'true'
       Content-Type:
       - application/json
-      X-Restli-Protocol-Version:
-      - 1.0.0
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:01 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:04 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927641:t=1527014039:s=AQFnfvd17C3wntwvnDGCCgAhGHxsNmrS"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927641:t=1527014039:s=AQFnfvd17C3wntwvnDGCCgAhGHxsNmrS"'
       X-Li-Uuid:
-      - I0OanJm8MBWQcFrp1CoAAA==
+      - AAXVaV7pX5pI9vz+mXMW0Q==
+      Set-Cookie:
+      - bcookie="v=2&66f743a9-caeb-4617-8215-b13acb015960"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:36 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023424:t=1642025283:v=2:sig=AQG9cK7snZdg2V-yqDzMEAMeFEUJiOoP"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023424:t=1642025283:v=2:sig=AQG9cK7snZdg2V-yqDzMEAMeFEUJiOoP"'
     body:
       encoding: UTF-8
-      string: '{"industryName":{"localized":{"en_US":"Public Relations"},"preferredLocale":{"country":"US","language":"en"}},"localizedLastName":"Santos
-        del Nariz","lastName":{"localized":{"en_US":"Santos del Nariz"},"preferredLocale":{"country":"US","language":"en"}},"vanityName":"miguel-santos-del-nariz","positions":{"1231524997":{"startMonthYear":{"year":2014},"companyName":{"localized":{"en_US":"Ceres
-        Logic"},"preferredLocale":{"country":"US","language":"en"}},"title":{"localized":{"en_US":"Social
-        Media Specialist"},"preferredLocale":{"country":"US","language":"en"}}},"1069560016":{"startMonthYear":{"year":2009},"endMonthYear":{"year":2014},"companyName":{"localized":{"en_US":"Winletric"},"preferredLocale":{"country":"US","language":"en"}},"title":{"localized":{"en_US":"Warehouse
-        Manager"},"preferredLocale":{"country":"US","language":"en"}}}},"pictureInfo":{"croppedImage":"urn:li:media:/gcrc/dms/image/C4E03AQEmhyl0HXzfGQ/profile-displayphoto-shrink_800_800/0?e=1532563200&v=beta&t=YgAaVHRcz-kCCjO0q4tLFqKCfagER0x4cba-AnuCFlY","masterImage":"urn:li:media:/gcrc/dms/image/C4E00AQFBxXq_zXDwiw/profile-originalphoto-shrink_900_1200/0?e=1527015600&v=beta&t=h4OmZxStzQ30Db1m1Qxe8h9Ll54_Z_eXZqYsBtfGia4","photoFilterEditInfo":{"bottomLeft":{"x":-6.178632484870436E-17,"y":1.0},"saturation":0.0,"brightness":0.0,"vignette":0.0,"photoFilterType":"ORIGINAL","bottomRight":{"x":1.0,"y":1.0},"topLeft":{"x":-6.178632484870436E-17,"y":0.0},"contrast":0.0,"topRight":{"x":1.0,"y":0.0}}},"firstName":{"localized":{"en_US":"Miguel"},"preferredLocale":{"country":"US","language":"en"}},"profilePicture":{"displayImage":"urn:li:digitalmediaAsset:C4E03AQEmhyl0HXzfGQ","created":1505332528742,"lastModified":1505332528742,"photoFilterEditInfo":{"bottomLeft":{"x":-6.178632484870436E-17,"y":1.0},"saturation":0.0,"brightness":0.0,"vignette":0.0,"photoFilterType":"ORIGINAL","bottomRight":{"x":1.0,"y":1.0},"topLeft":{"x":-6.178632484870436E-17,"y":0.0},"contrast":0.0,"topRight":{"x":1.0,"y":0.0}}},"industryId":"urn:li:industry:4","location":{"countryCode":"us","postalCode":"04768","userSelectedGeoPlaceCode":"5-2-0-2-29","standardizedLocationUrn":"urn:li:standardizedLocationKey:(us,04768)"},"id":"MpkAFJTlPY","lastModified":1524678302559,"headline":{"localized":{"en_US":"Social
-        Media Specialist at Ceres Logic"},"preferredLocale":{"country":"US","language":"en"}},"localizedFirstName":"Miguel"}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:01 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:04 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_other_url.yml
+++ b/spec/vcr_cassettes/people_profile_other_url.yml
@@ -12,43 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 500
-      message: Server Error
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
+      X-Restli-Gateway-Error:
+      - 'true'
       Content-Type:
       - application/json
-      X-Linkedin-Error-Response:
-      - 'true'
-      X-Restli-Gateway-Error:
-      - 'false'
-      X-Restli-Protocol-Version:
-      - 1.0.0
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '93'
+      Date:
+      - Wed, 12 Jan 2022 21:37:04 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927642:t=1527014039:s=AQHHr3k2NymZYYLggEBOGWkjd-EZukzd"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927642:t=1527014039:s=AQHHr3k2NymZYYLggEBOGWkjd-EZukzd"'
       X-Li-Uuid:
-      - NUsjt5m8MBVQrG50SysAAA==
+      - AAXVaV7rxR+okLSoTxBbPw==
+      Set-Cookie:
+      - bcookie="v=2&3136a102-48de-484d-81f8-9ed603884cc2"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:36 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023424:t=1642025283:v=2:sig=AQG9cK7snZdg2V-yqDzMEAMeFEUJiOoP"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023424:t=1642025283:v=2:sig=AQG9cK7snZdg2V-yqDzMEAMeFEUJiOoP"'
     body:
       encoding: UTF-8
-      string: '{"message":"INTERNAL SERVER ERROR","status":500}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:02 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:04 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_own.yml
+++ b/spec/vcr_cassettes/people_profile_own.yml
@@ -12,46 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 200
-      message: OK
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
+      X-Restli-Gateway-Error:
+      - 'true'
       Content-Type:
       - application/json
-      X-Restli-Protocol-Version:
-      - 1.0.0
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:33:59 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:03 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927639:t=1527014039:s=AQFF3tE_rEXlxNHLXP4mAUnpECGyTyuo"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927639:t=1527014039:s=AQFF3tE_rEXlxNHLXP4mAUnpECGyTyuo"'
       X-Li-Uuid:
-      - M+8bBpm8MBVQMf3i1CoAAA==
+      - AAXVaV7b+t5I2b3ZT4uO5A==
+      Set-Cookie:
+      - bcookie="v=2&c6e83fc1-afa0-49fd-8417-34e232655265"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:35 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023423:t=1642025283:v=2:sig=AQFdi9Qro7L-lDc92ApInuGYvWinMXDm"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023423:t=1642025283:v=2:sig=AQFdi9Qro7L-lDc92ApInuGYvWinMXDm"'
     body:
       encoding: UTF-8
-      string: '{"industryName":{"localized":{"en_US":"Public Relations"},"preferredLocale":{"country":"US","language":"en"}},"localizedLastName":"Santos
-        del Nariz","lastName":{"localized":{"en_US":"Santos del Nariz"},"preferredLocale":{"country":"US","language":"en"}},"vanityName":"miguel-santos-del-nariz","positions":{"1231524997":{"startMonthYear":{"year":2014},"companyName":{"localized":{"en_US":"Ceres
-        Logic"},"preferredLocale":{"country":"US","language":"en"}},"title":{"localized":{"en_US":"Social
-        Media Specialist"},"preferredLocale":{"country":"US","language":"en"}}},"1069560016":{"startMonthYear":{"year":2009},"endMonthYear":{"year":2014},"companyName":{"localized":{"en_US":"Winletric"},"preferredLocale":{"country":"US","language":"en"}},"title":{"localized":{"en_US":"Warehouse
-        Manager"},"preferredLocale":{"country":"US","language":"en"}}}},"pictureInfo":{"croppedImage":"urn:li:media:/gcrc/dms/image/C4E03AQEmhyl0HXzfGQ/profile-displayphoto-shrink_800_800/0?e=1532563200&v=beta&t=YgAaVHRcz-kCCjO0q4tLFqKCfagER0x4cba-AnuCFlY","masterImage":"urn:li:media:/gcrc/dms/image/C4E00AQFBxXq_zXDwiw/profile-originalphoto-shrink_900_1200/0?e=1527015600&v=beta&t=h4OmZxStzQ30Db1m1Qxe8h9Ll54_Z_eXZqYsBtfGia4","created":1505332528742,"lastModified":1505332528742},"firstName":{"localized":{"en_US":"Miguel"},"preferredLocale":{"country":"US","language":"en"}},"profilePicture":{"displayImage":"urn:li:digitalmediaAsset:C4E03AQEmhyl0HXzfGQ","created":1505332528742,"lastModified":1505332528742,"originalImage":"urn:li:digitalmediaAsset:C4E04AQFBxXq_zXDwiw","photoFilterEditInfo":{"bottomLeft":{"x":-6.178632484870436E-17,"y":1.0},"saturation":0.0,"brightness":0.0,"vignette":0.0,"photoFilterType":"ORIGINAL","bottomRight":{"x":1.0,"y":1.0},"topLeft":{"x":-6.178632484870436E-17,"y":0.0},"contrast":0.0,"topRight":{"x":1.0,"y":0.0}}},"industryId":"urn:li:industry:4","location":{"countryCode":"us","postalCode":"04768","userSelectedGeoPlaceCode":"5-2-0-2-29","standardizedLocationUrn":"urn:li:standardizedLocationKey:(us,04768)"},"id":"MpkAFJTlPY","lastModified":1524678302559,"headline":{"localized":{"en_US":"Social
-        Media Specialist at Ceres Logic"},"preferredLocale":{"country":"US","language":"en"}},"localizedFirstName":"Miguel"}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:33:59 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:03 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_own_secure.yml
+++ b/spec/vcr_cassettes/people_profile_own_secure.yml
@@ -12,42 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 403
-      message: Forbidden
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:33:59 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:03 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927639:t=1527014039:s=AQFF3tE_rEXlxNHLXP4mAUnpECGyTyuo"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927639:t=1527014039:s=AQFF3tE_rEXlxNHLXP4mAUnpECGyTyuo"'
       X-Li-Uuid:
-      - EhBZKpm8MBWAHOVjdSsAAA==
+      - AAXVaV7ec7jAEVKlAJrmNw==
+      Set-Cookie:
+      - bcookie="v=2&3cbdecee-145a-4d1b-86f3-ba7e46c30c9d"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:35 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023423:t=1642025283:v=2:sig=AQFdi9Qro7L-lDc92ApInuGYvWinMXDm"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023423:t=1642025283:v=2:sig=AQFdi9Qro7L-lDc92ApInuGYvWinMXDm"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":100,"message":"Unpermitted fields present in PARAMETER:
-        Data Processing Exception while processing fields [/secure]","status":403}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:33:59 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:03 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/people_profile_skills.yml
+++ b/spec/vcr_cassettes/people_profile_skills.yml
@@ -12,41 +12,45 @@ http_interactions:
       Authorization:
       - Bearer AQVM91zzF-bLiOfCsTi8ktxnq99l-tW9meri8F9ZEWAuHf5g1bO_Pa4p0nFwKvZ7VFdSERAnJZq3eNOq6BzDPFNIyGIy50s-7HkLq2hE5uy6HrAQrsMAQR_qZxnBrSD11g_M2sF5XB5fUHZOXEQFgFaXB0M19VUAsvsz3yg-7zMI7w9Zn_DYTLO1e2W9VEZrOgVmRNt1XBIT_pdQO7pQkKv4702yJTrIBOuhZWNLZRClPHd2RRhPf2SJeTkodbnL4xSvzcyEPpLaTPyZIVJnBcsAzYFiG_pJtyGs7x-iWbUZsYgnUVSy8Wg-5eqmvze5tuZdICIP0PJ0AVMNGOxRRiLOEh8MSg
       User-Agent:
-      - Faraday v0.12.2
+      - Faraday v1.8.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 401
+      message: Unauthorized
     headers:
+      X-Li-Responseorigin:
+      - RGW
       X-Restli-Gateway-Error:
       - 'true'
       Content-Type:
       - application/json
+      Content-Length:
+      - '93'
       Date:
-      - Mon, 21 May 2018 18:34:08 GMT
-      X-Li-Fabric:
-      - prod-lva1
-      Transfer-Encoding:
-      - chunked
+      - Wed, 12 Jan 2022 21:37:06 GMT
       Connection:
       - keep-alive
+      X-Li-Fabric:
+      - prod-lva1
       X-Li-Pop:
-      - prod-edc2
+      - prod-lva1-x
       X-Li-Proto:
       - http/1.1
-      Set-Cookie:
-      - lidc="b=VB96:g=1172:u=20:i=1526927648:t=1527014039:s=AQFJz1E6LhBREEpyVTwL3BUCK1v6VMsD"
-      X-Li-Route-Key:
-      - '"b=VB96:g=1172:u=20:i=1526927648:t=1527014039:s=AQFJz1E6LhBREEpyVTwL3BUCK1v6VMsD"'
       X-Li-Uuid:
-      - WI5lF5u8MBWggUJ7disAAA==
+      - AAXVaV8TdBzktKwQ3fhM/g==
+      Set-Cookie:
+      - bcookie="v=2&a34f3b20-b5b7-4369-8292-97a93bdca1d8"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:38 GMT; SameSite=None
+      - lidc="b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023426:t=1642025283:v=2:sig=AQEZvIKTWpnHazXJ1WA0C2Wj_0fSMKZk"
+      X-Li-Route-Key:
+      - '"b=VB96:s=V:r=V:a=V:p=V:g=2650:u=117:x=1:i=1642023426:t=1642025283:v=2:sig=AQEZvIKTWpnHazXJ1WA0C2Wj_0fSMKZk"'
     body:
       encoding: UTF-8
-      string: '{"serviceErrorCode":0,"message":"Resource me does not exist","status":404}'
-    http_version: 
-  recorded_at: Mon, 21 May 2018 18:34:08 GMT
-recorded_with: VCR 4.0.0
+      string: '{"serviceErrorCode":65602,"message":"The token used in the request
+        has expired","status":401}'
+  recorded_at: Wed, 12 Jan 2022 21:37:06 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/unavailable.yml
+++ b/spec/vcr_cassettes/unavailable.yml
@@ -94,6 +94,96 @@ http_interactions:
         to handle the request : RestException{_response=RestResponse[headers={Content-Length=10592,
         Content-Type=application/json, X-RestLi-Error-Response=true, X-RestLi-Protocol-Version=2.0.0}cookies=[],status=404,entityLength=10592]}
         ","error":"temporarily_unavailable"}'
-    http_version: 
   recorded_at: Mon, 21 May 2018 18:34:13 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: post
+    uri: https://www.linkedin.com/oauth/v2/accessToken
+    body:
+      encoding: UTF-8
+      string: client_id=dummy_client_id&client_secret=dummy_client_secret&code=dummy_code&grant_type=authorization_code&raise_errors=true&redirect_uri=http%3A%2F%2Flvh.me%3A5000
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '116'
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Vary:
+      - Accept-Encoding
+      Set-Cookie:
+      - bcookie="v=2&26e1a11d-78b6-4013-8373-11d1ef96a18d"; domain=.linkedin.com;
+        Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:43 GMT; SameSite=None
+      - bscookie="v=1&2022011221371145b0189c-c071-435c-8618-13fd7f345cb0AQHxIEPd-fRCmgT_ascoPkVGa9qUT-8g";
+        domain=.www.linkedin.com; Path=/; Secure; Expires=Sat, 13-Jan-2024 09:14:43
+        GMT; HttpOnly; SameSite=None
+      - lang=v=2&lang=en-us; SameSite=None; Path=/; Domain=linkedin.com; Secure
+      - lidc="b=VB04:s=V:r=V:a=V:p=V:g=4011:u=1:x=1:i=1642023431:t=1642109831:v=2:sig=AQGw8HnSeVfCNHlhZzNYeuX_NwnUxT29";
+        Expires=Thu, 13 Jan 2022 21:37:11 GMT; domain=.linkedin.com; Path=/; SameSite=None;
+        Secure
+      Expect-Ct:
+      - max-age=86400, report-uri="https://www.linkedin.com/platform-telemetry/ct"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - 'default-src *; connect-src ''self'' https://media-src.linkedin.com/media/
+        www.linkedin.com s.c.lnkd.licdn.com m.c.lnkd.licdn.com wss://*.linkedin.com
+        dms.licdn.com https://dpm.demdex.net/id lnkd.demdex.net blob: https://accounts.google.com/gsi/status
+        https://linkedin.sc.omtrdc.net/b/ss/ www.google-analytics.com static.licdn.com
+        static-exp1.licdn.com static-exp2.licdn.com static-exp3.licdn.com media.licdn.com
+        media-exp1.licdn.com media-exp2.licdn.com media-exp3.licdn.com; img-src data:
+        blob: *; font-src data: *; style-src ''unsafe-inline'' ''self'' static-src.linkedin.com
+        *.licdn.com; script-src ''report-sample'' ''unsafe-inline'' ''unsafe-eval''
+        ''self'' spdy.linkedin.com static-src.linkedin.com *.ads.linkedin.com *.licdn.com
+        static.chartbeat.com www.google-analytics.com ssl.google-analytics.com bcvipva02.rightnowtech.com
+        www.bizographics.com sjs.bizographics.com js.bizographics.com d.la4-c1-was.salesforceliveagent.com
+        https://snap.licdn.com/li.lms-analytics/ platform.linkedin.com platform-akam.linkedin.com
+        platform-ecst.linkedin.com platform-azur.linkedin.com; object-src ''none'';
+        media-src blob: *; child-src blob: lnkd-communities: voyager: *; frame-ancestors
+        ''self''; report-uri /security/csp?e=p&f=l'
+      X-Frame-Options:
+      - sameorigin
+      X-Li-Fabric:
+      - prod-lva1
+      Report-To:
+      - '{"group":"network-errors","max_age":2592000,"endpoints":[{"url":"https://www.linkedin.com/li/rep"}],"include_subdomains":true}'
+      Nel:
+      - '{"report_to":"network-errors","max_age":1296000,"success_fraction":0.00066,"failure_fraction":1,"include_subdomains":true}'
+      X-Fs-Uuid:
+      - 0005d5695f55828d97c9222cbb9e6f28
+      X-Li-Pop:
+      - afd-prod-lva1-x
+      X-Li-Proto:
+      - http/1.1
+      X-Li-Uuid:
+      - AAXVaV9Vgo2XySIsu55vKA==
+      X-Cache:
+      - CONFIG_NOCACHE
+      X-Msedge-Ref:
+      - 'Ref A: 22F458C191EB4332973C68C6FFE8BE41 Ref B: BNA30EDGE0412 Ref C: 2022-01-12T21:37:11Z'
+      Date:
+      - Wed, 12 Jan 2022 21:37:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":"invalid_request","error_description":"Unable to retrieve
+        access token: authorization code not found"}'
+  recorded_at: Wed, 12 Jan 2022 21:37:11 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
The RichMediaShares API was deprecated in March 2020. This PR upgrades the Media class to use the Assets API.

The `register_upload` method takes an entity type (person or organization) and a urn and registers an upload with the LinkedIn API. 

The `upload` method has been updated to additionally take the same two arguments and calls the `register_upload` method. The `upload` method then uses the URL returned from the `register_upload` response and PUTs the media file to that endpoint. Finally, if the upload was successful, the `upload` method returns the asset urn so that the media can be used with e.g. the Shares API.